### PR TITLE
fixed case of creating unhandled rejections

### DIFF
--- a/lib/batch_river.js
+++ b/lib/batch_river.js
@@ -1,5 +1,6 @@
 'use strict';
 const River = require('wise-river');
+const noop = () => {};
 
 /*
   Batch incoming items into an object that gets written out either after the
@@ -26,7 +27,7 @@ module.exports = (input, maxSize, timeout = null, handler) => new River((resolve
   input.then(() => {
     inputDone = true;
     checkIfDone();
-  });
+  }, noop);
   function checkIfDone() {
     if (inputDone && pendingFeedback === 0) {
       if (size === 0) fResolve();


### PR DESCRIPTION
`input.then(...)` returns a new promise that will be rejected if `input` was rejected, and even though `input` is being handled by `River.combine()`, that new discarded promise is not being handled.